### PR TITLE
Update etherlink.py

### DIFF
--- a/scripts/etherlink.py
+++ b/scripts/etherlink.py
@@ -123,7 +123,7 @@ def deploy_erc20(
             kernel_address,
             token_name,
             token_symbol,
-            '0',
+            decimals,
             '--gas-limit',
             '200000',
         ],


### PR DESCRIPTION
Fix `decimals` argument value for `ERC20Proxy` constructor