### PR TITLE
PyTezos tests fixes & withdraw via Web3

### DIFF
--- a/docs/Bridge-configuration.md
+++ b/docs/Bridge-configuration.md
@@ -1,0 +1,55 @@
+### Bridge configuration
+To configure the bridge for a new token (i.e., to list a new token pair), users need to engage with the **Ticket Transport Layer**. This critical component of the bridge facilitates the transfer of tickets between Tezos and Etherlink.
+
+![permissionless ticket transfer short illustration](permissionless-ticket-transfer.png)
+
+The **FA2** and **FA1.2** standard Tezos tokens are not inherently ticket-native. Therefore, to bridge these tokens, users must initially convert them to tickets. To do this they first need to deploy a **Ticketer** contract on the Tezos side. This contract will be associated with the specific Tezos token and provide entrypoint to wrap them into tickets. This contract is unnecessary for the forthcoming tokens that are ticket-native, such as those following **FA2.1** standard.
+
+NOTE: Upgrades to the Ticketer contract are highly unwanted because this will lead to liquidity fragmentation. Ideally, it should be deployed once and remain unchanged indefinitely.
+
+Once it's determined what **Ticketer** will represent the token, users can deploy an **ERC20Proxy** – an ERC20 token integrated with bridge deposit and withdrawal interfaces. The Ticketer address and ticket content are provided to the ERC20Proxy constructor during origination to bind the L2 token to the L1 ticket. It is also required to provide rollup kernel address to the ERC20 proxy which will be allowed to mint and burn tokens which is the `0x00` address.
+
+Additionally, deploying a **TokenBridgeHelper** on the Tezos side is required, targeting the specific **Token** and **Ticketer** pair on the L1 side and **ERC20Proxy** address on the L2 side. This deployment is crucial since wallets currently do not support the **transfer_ticket** operation. The **TokenBridgeHelper** streamlines the process by wrapping tokens into tickets and enabling their transfer to the rollup in a single transaction. Note, however, that this type of contract may become obsolete in the future when (1) wallets begin supporting the **transfer_ticket** operation and (2) Tezos undergoes a protocol upgrade that permits implicit addresses to transfer tickets with arbitrary data.
+
+#### Deploying a Token
+For demonstration purposes, users can deploy a test token intended for bridging. The bridge has been tested with two types of tokens available in the repository:
+- The **FA1.2** standard **Ctez** token.
+- The **FA2** standard **fxhash** token.
+
+To deploy a test version of a token and allocate the total supply to the token's originator, the `deploy_token` command can be used. It is possible to configure `--token-type`, `--token-id`, and `--total-supply` providing these params to the command. The following example demonstrates how to deploy an **FA1.2** token type using default parameters:
+```shell
+poetry run deploy_token --token-type FA1.2 --total-supply 1000
+```
+Here is an example of the deployed [token](https://oxfordnet.tzkt.io/KT1QKYoSpV5BLKg8xoexG25yZwA1sjVrrymU/operations/).
+
+#### Deploying a Ticketer
+The `deploy_ticketer` command can be used to deploy a ticketer configured for a specific token. It requires the `--token-address`, `--token-type`, and `--token-id` parameters to be provided. Below is an example that demonstrates how to deploy a ticketer for the **FA1.2** token previously deployed on Oxfordnet:
+```shell
+poetry run deploy_ticketer --token-address KT1QKYoSpV5BLKg8xoexG25yZwA1sjVrrymU --token-type FA1.2
+```
+Here is an example of the deployed [ticketer](https://oxfordnet.tzkt.io/KT1C2gmhvA1FrscWe8KbrHf8dWG9XJETR127/metadata).
+
+After the Ticketer contract is deployed, users can obtain the parameters required for the **ERC20Proxy** origination, **ticketer-address_bytes** and **content_bytes**. To do this users can execute `get_ticketer_params` command:
+```shell
+poetry run get_ticketer_params --ticketer KT1C2gmhvA1FrscWe8KbrHf8dWG9XJETR127
+```
+
+For example, the ticketer deployed in the previous step has the following parameters:
+```
+address_bytes: 0125cf30bfba37ed7907f524f7b4eaf304e03d097600
+content_bytes: 0707000005090a0000005f05020000005907040100000010636f6e74726163745f616464726573730a0000001c050a0000001601aca11e3f7734be9b46df1642a7d5f7d66c7bf6e8000704010000000a746f6b656e5f747970650a0000000b0501000000054641312e32
+```
+
+#### Deploying ERC20Proxy
+Then, to deploy a token contract on the Etherlink side, the `deploy_erc20` command can be used. This script requires the `--ticketer-address-bytes` and `--ticketer-content-bytes`, as well as `--token-name`, `--token-symbol`, and `--decimals` to be provided for the L2 token contract configuration. Below is an example that originates ERC20 contract connected to the ticketer previously deployed:
+```shell
+poetry run deploy_erc20 --ticketer-address-bytes 0125cf30bfba37ed7907f524f7b4eaf304e03d097600 --ticket-content-bytes 0707000005090a0000005f05020000005907040100000010636f6e74726163745f616464726573730a0000001c050a0000001601aca11e3f7734be9b46df1642a7d5f7d66c7bf6e8000704010000000a746f6b656e5f747970650a0000000b0501000000054641312e32 --token-name "FA1.2 Test Token" --token-symbol "FA1.2" --decimals 0
+```
+Here is an example of the deployed [token](http://blockscout.dipdup.net/address/0x03E39FF2b379FBcd9284Ab457113D82fF4daBBF4).
+
+#### Deploying a Token Bridge Helper
+Finally, to allow the interaction of Tezos wallets with tickets, users need to deploy a Token Bridge Helper. During origination, Token Bridge Helper linked to the Token, Ticketer and ERC20Proxy. To originate Token Bridge Helper user should run the `deploy_token_bridge_helper` command, which requires the `--ticketer-address` and `--proxy-address` (the address of the L2 token) parameters to be provided. The Ticketer's storage will be parsed to retrieve information about the token. Below is an example that illustrates deploying a token bridge helper for the previously deployed ticketer and proxy:
+```shell
+poetry run deploy_token_bridge_helper --ticketer-address KT1C2gmhvA1FrscWe8KbrHf8dWG9XJETR127 --proxy-address 0x03E39FF2b379FBcd9284Ab457113D82fF4daBBF4
+```
+Here is an example of the deployed [helper](https://oxfordnet.tzkt.io/KT1RWw9NyPDZm9jeiEA1hXMd4PgGQVPHYrzj/metadata).

--- a/poetry.lock
+++ b/poetry.lock
@@ -3765,49 +3765,36 @@ typing = ["mypy (>=1.6,<2.0)", "traitlets (>=5.11.1)"]
 
 [[package]]
 name = "testcontainers"
-version = "4.7.0"
-description = "Python library for throwaway instances of anything that can run in a Docker container"
+version = "3.7.1"
+description = "Library provides lightweight, throwaway instances of common databases, Selenium web browsers, or anything else that can run in a Docker container"
 optional = false
-python-versions = "<4.0,>=3.9"
+python-versions = ">=3.7"
 files = [
-    {file = "testcontainers-4.7.0-py3-none-any.whl", hash = "sha256:7c37dc610395940e5f0c67c97eeba1889ab7ec9b689f0c8b73d7fa7fe7baf3c9"},
-    {file = "testcontainers-4.7.0.tar.gz", hash = "sha256:89c11f02f98093e3811346556707209278a7b7a4d9e18170cdae80668909cb8b"},
+    {file = "testcontainers-3.7.1-py2.py3-none-any.whl", hash = "sha256:7f48cef4bf0ccd78f1a4534d4b701a003a3bace851f24eae58a32f9e3f0aeba0"},
 ]
 
 [package.dependencies]
-docker = "*"
-typing-extensions = "*"
-urllib3 = "*"
+deprecation = "*"
+docker = ">=4.0.0"
 wrapt = "*"
 
 [package.extras]
-arangodb = ["python-arango (>=7.8,<8.0)"]
-azurite = ["azure-storage-blob (>=12.19,<13.0)"]
-chroma = ["chromadb-client"]
+arangodb = ["python-arango"]
+azurite = ["azure-storage-blob"]
 clickhouse = ["clickhouse-driver"]
-cosmosdb = ["azure-cosmos"]
-generic = ["httpx"]
-google = ["google-cloud-datastore (>=2)", "google-cloud-pubsub (>=2)"]
-influxdb = ["influxdb", "influxdb-client"]
-k3s = ["kubernetes", "pyyaml"]
+docker-compose = ["docker-compose"]
+google-cloud-pubsub = ["google-cloud-pubsub (<2)"]
+kafka = ["kafka-python"]
 keycloak = ["python-keycloak"]
-localstack = ["boto3"]
-minio = ["minio"]
-mongodb = ["pymongo"]
-mssql = ["pymssql", "sqlalchemy"]
-mysql = ["pymysql[rsa]", "sqlalchemy"]
-nats = ["nats-py"]
+mongo = ["pymongo"]
+mssqlserver = ["pymssql"]
+mysql = ["pymysql", "sqlalchemy"]
 neo4j = ["neo4j"]
-opensearch = ["opensearch-py"]
-oracle = ["oracledb", "sqlalchemy"]
-oracle-free = ["oracledb", "sqlalchemy"]
-qdrant = ["qdrant-client"]
+oracle = ["cx-Oracle", "sqlalchemy"]
+postgresql = ["psycopg2-binary", "sqlalchemy"]
 rabbitmq = ["pika"]
 redis = ["redis"]
-registry = ["bcrypt"]
 selenium = ["selenium"]
-testmoduleimport = ["httpx"]
-weaviate = ["weaviate-client (>=4.5.4,<5.0.0)"]
 
 [[package]]
 name = "tinycss2"
@@ -4324,4 +4311,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.13"
-content-hash = "5a560e181b706eac9989ca5e26a0c279d5500eb5adbf5db3ae6c1271b8abf402"
+content-hash = "21633a69b25c8d1c26c09fbe077894a72c37085053385ee1ddeb21d63841501d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ click = "^8.1.7"
 eth-abi = "^5.1.0"
 web3 = "^6.20.0"
 survey = "^5.3.0"
+testcontainers = "^3.7.1"
 
 [tool.poetry.group.dev.dependencies]
 ipython = "^8.21.0"

--- a/scripts/bootstrap/bootstrap.py
+++ b/scripts/bootstrap/bootstrap.py
@@ -176,7 +176,7 @@ class TokenBootstrap:
                 self._tezos_client.context.shell,
             )
 
-            ticket_hash = ticketer.get_ticket_hash(ticketer_params_dict)
+            ticket_hash = ticketer.read_ticket().hash()
 
             ticketer_params = TicketerParamsDTO(
                 address_bytes_hex=ticketer_params_dict['address_bytes'],

--- a/scripts/bridge_token.py
+++ b/scripts/bridge_token.py
@@ -23,6 +23,7 @@ from typing import Any, Dict, Optional
 @click.option(
     '--decimals',
     required=True,
+    default=0,
     help='Token decimals added to the ERC20 token and ticketer metadata content.',
 )
 @click.option(
@@ -115,6 +116,7 @@ def bridge_token(
         proxy_address=erc_20_address,
         private_key=tezos_private_key,
         rpc_url=tezos_rpc_url,
+        symbol=symbol,
     )  # type: ignore
 
     return {

--- a/scripts/bridge_token.py
+++ b/scripts/bridge_token.py
@@ -50,8 +50,8 @@ from typing import Any, Dict, Optional
 @click.option('--etherlink-rpc-url', default=None, help='Etherlink RPC URL.')
 @click.option(
     '--kernel-address',
-    default=None,
-    help='The address of the Etherlink kernel which will be managing token.',
+    default='0x0000000000000000000000000000000000000000',
+    help='The address of the Etherlink kernel which will be managing token. Default `0x0000000000000000000000000000000000000000`',
 )
 def bridge_token(
     token_address: str,
@@ -64,7 +64,7 @@ def bridge_token(
     tezos_rpc_url: Optional[str],
     etherlink_private_key: Optional[str],
     etherlink_rpc_url: Optional[str],
-    kernel_address: Optional[str],
+    kernel_address: str,
 ) -> Dict[str, Any]:
     """Deploys bridge contracts for a new token:
     - Ticketer

--- a/scripts/etherlink/deploy_erc20.py
+++ b/scripts/etherlink/deploy_erc20.py
@@ -5,7 +5,7 @@ from scripts.environment import (
     get_etherlink_web3,
     get_etherlink_account,
 )
-from scripts.etherlink.erc20_helper import Erc20ProxyHelper
+from scripts.helpers.etherlink import Erc20ProxyHelper
 
 
 @click.command()

--- a/scripts/helpers/contracts/ticketer.py
+++ b/scripts/helpers/contracts/ticketer.py
@@ -1,7 +1,7 @@
 from os.path import join
 from typing import Any
 
-from eth_abi import decode
+from eth_abi import decode  # type: ignore
 from pytezos.client import PyTezosClient
 from pytezos.contract.call import ContractCall
 from pytezos.operation.group import OperationGroup
@@ -25,8 +25,11 @@ class Ticketer(ContractHelper):
         extra_token_info: TokenInfo,
         content_token_id: int = 0,
     ) -> dict[str, Any]:
+        """Creates storage for the Ticketer contract"""
+
+        symbol = extra_token_info.get('symbol') if extra_token_info else None
         metadata = Metadata.make_default(
-            name=f'Ticketer: {extra_token_info["symbol"][6:].decode()}',
+            name=f'Ticketer: {symbol}' if symbol else 'Ticketer',
             description='The Ticketer is a component of the Etherlink Bridge, designed to wrap legacy FA2 and FA1.2 tokens to tickets.',
         )
         content = (content_token_id, token.make_token_info_bytes(extra_token_info))
@@ -109,7 +112,7 @@ class Ticketer(ContractHelper):
                 '0x' + ticketer_params['content_bytes'],
             ],
         )
-        ticket_hash = decode(['uint256'], data)[0]
+        ticket_hash: int = decode(['uint256'], data)[0]
         return ticket_hash
 
     def get_content_bytes_hex(self) -> str:

--- a/scripts/helpers/contracts/token_bridge_helper.py
+++ b/scripts/helpers/contracts/token_bridge_helper.py
@@ -32,15 +32,17 @@ class TokenBridgeHelper(ContractHelper):
         """Deploys Token Bridge Helper"""
 
         token = token or ticketer.get_token()
+        name = f"Token Bridge Helper: {symbol}" if symbol else "Token Bridge Helper"
         storage = {
             'token': token.as_dict(),
             'ticketer': ticketer.address,
             'erc_proxy': erc_proxy,
             'context': None,
             'metadata': Metadata.make_default(
-                name=': '.join(filter(bool, ['Token Bridge Helper', symbol])),
-                description='The Token Bridge Helper is a helper contract which helps user to communicate with Etherlink Bridge ' +
-                            'components that requires tickets to be packed into external data structure.',
+                name=name,
+                description='The Token Bridge Helper is a helper contract which '
+                + 'helps user to communicate with Etherlink Bridge components '
+                + 'that requires tickets to be packed into external data structure.',
             ),
         }
         filename = join(get_build_dir(), 'token-bridge-helper.tz')

--- a/scripts/helpers/contracts/tokens/fa12/fa12.py
+++ b/scripts/helpers/contracts/tokens/fa12/fa12.py
@@ -41,10 +41,10 @@ class FA12(TokenHelper):
     def as_tuple(self) -> FA12AsTupleType:
         return ('fa12', self.address)
 
-    def make_token_info(self) -> dict[str, bytes]:
+    def make_token_info(self) -> dict[str, str]:
         return {
-            'contract_address': self.address.encode('utf-8'),
-            'token_type': "FA1.2".encode('utf-8'),
+            'contract_address': self.address,
+            'token_type': "FA1.2",
         }
 
     def get_balance(self, client_or_contract: Addressable) -> int:

--- a/scripts/helpers/contracts/tokens/fa2/fa2.py
+++ b/scripts/helpers/contracts/tokens/fa2/fa2.py
@@ -56,11 +56,11 @@ class FA2(TokenHelper):
         assert isinstance(balance, int)
         return balance
 
-    def make_token_info(self) -> dict[str, bytes]:
+    def make_token_info(self) -> dict[str, str]:
         return {
-            'contract_address': self.address.encode('utf-8'),
-            'token_type': "FA2".encode('utf-8'),
-            'token_id': str(self.token_id).encode('utf-8'),
+            'contract_address': self.address,
+            'token_type': "FA2",
+            'token_id': str(self.token_id),
         }
 
     @classmethod

--- a/scripts/helpers/contracts/tokens/token.py
+++ b/scripts/helpers/contracts/tokens/token.py
@@ -10,7 +10,7 @@ from scripts.helpers.addressable import Addressable
 
 
 TicketContent = tuple[int, Optional[bytes]]
-TokenInfo = Optional[dict[str, bytes]]
+TokenInfo = Optional[dict[str, str]]
 
 # Map token info type is the same as token info metadata in FA2:
 MAP_TOKEN_INFO_TYPE = 'map %token_info string bytes'
@@ -27,7 +27,7 @@ class TokenHelper(ContractHelper):
         client: PyTezosClient,
         balances: dict[Addressable, int],
         token_id: int = 0,
-        token_info: dict[str, bytes] = None,
+        token_info: TokenInfo = None,
     ) -> OperationGroup: ...
 
     @abstractmethod
@@ -46,7 +46,7 @@ class TokenHelper(ContractHelper):
     def get_balance(self, client_or_contract: Addressable) -> int: ...
 
     @abstractmethod
-    def make_token_info(self) -> dict[str, bytes]: ...
+    def make_token_info(self) -> dict[str, str]: ...
 
     def make_token_info_bytes(
         self,
@@ -61,8 +61,11 @@ class TokenHelper(ContractHelper):
             **self.make_token_info(),
             **extra_token_info,
         }
+        token_info_bytes = {
+            key: value.encode('utf-8') for key, value in token_info.items()
+        }
 
-        return pack(token_info, MAP_TOKEN_INFO_TYPE)
+        return pack(token_info_bytes, MAP_TOKEN_INFO_TYPE)
 
     @classmethod
     def from_dict(cls, client: PyTezosClient, token_dict: dict) -> 'TokenHelper':

--- a/scripts/helpers/etherlink/__init__.py
+++ b/scripts/helpers/etherlink/__init__.py
@@ -1,0 +1,14 @@
+from scripts.helpers.etherlink.erc20_proxy import Erc20ProxyHelper
+from scripts.helpers.etherlink.fa_withdrawal_precompile import (
+    FaWithdrawalPrecompileHelper,
+)
+from scripts.helpers.etherlink.contract import load_contract_type, originate_contract
+
+
+# Allowing reimporting from this module:
+__all__ = [
+    'Erc20ProxyHelper',
+    'FaWithdrawalPrecompileHelper',
+    'load_contract_type',
+    'originate_contract',
+]

--- a/scripts/helpers/etherlink/erc20_proxy.py
+++ b/scripts/helpers/etherlink/erc20_proxy.py
@@ -1,0 +1,42 @@
+from web3 import Web3
+from eth_account.signers.local import LocalAccount
+from scripts.helpers.etherlink.contract import (
+    load_contract_type,
+    originate_contract,
+    EvmContractHelper,
+)
+
+
+class Erc20ProxyHelper(EvmContractHelper):
+    @classmethod
+    def originate(
+        cls,
+        web3: Web3,
+        account: LocalAccount,
+        ticketer: bytes,
+        content: bytes,
+        kernel: str,
+        name: str,
+        symbol: str,
+        decimals: int,
+    ) -> 'Erc20ProxyHelper':
+        """Deploys ERC20 Proxy contract with given parameters"""
+
+        ERC20Proxy = load_contract_type(web3, 'ERC20Proxy')
+        constructor = ERC20Proxy.constructor(
+            ticketer, content, kernel, name, symbol, decimals
+        )
+
+        tx_hash = originate_contract(
+            web3=web3,
+            account=account,
+            constructor=constructor,
+            gas_limit=30_000_000,
+            gas_price=web3.to_wei('1', 'gwei'),
+            nonce=None,
+        )
+        tx_receipt = web3.eth.wait_for_transaction_receipt(tx_hash)
+        address = tx_receipt.contractAddress  # type: ignore
+        contract = web3.eth.contract(address=address, abi=ERC20Proxy.abi)
+
+        return cls(contract=contract, web3=web3, account=account, address=address)

--- a/scripts/helpers/etherlink/fa_withdrawal_precompile.py
+++ b/scripts/helpers/etherlink/fa_withdrawal_precompile.py
@@ -1,0 +1,35 @@
+from web3.types import TxReceipt
+from scripts.helpers.etherlink.contract import EvmContractHelper
+
+
+class FaWithdrawalPrecompileHelper(EvmContractHelper):
+    def withdraw(
+        self,
+        ticket_owner: str,
+        routing_info: bytes,
+        # TODO: consider using BigNumber instead of int
+        amount: int,
+        ticketer: bytes,
+        content: bytes,
+    ) -> TxReceipt:
+        """Withdraws tokens from L2 to L1"""
+
+        transaction = self.contract.functions.withdraw(
+            ticket_owner, routing_info, amount, ticketer, content
+        ).build_transaction(
+            {
+                'from': self.account.address,
+                # TODO: check if gas limit can be reduced
+                'gas': 10_000_000,
+                'gasPrice': self.web3.to_wei('1', 'gwei'),
+                'nonce': self.web3.eth.get_transaction_count(self.account.address),
+                'chainId': self.web3.eth.chain_id,
+            }
+        )
+
+        signed_txn = self.web3.eth.account.sign_transaction(
+            transaction, self.account.key
+        )
+        txn_hash = self.web3.eth.send_raw_transaction(signed_txn.rawTransaction)
+        txn_receipt = self.web3.eth.wait_for_transaction_receipt(txn_hash)
+        return txn_receipt

--- a/scripts/helpers/ticket.py
+++ b/scripts/helpers/ticket.py
@@ -9,6 +9,9 @@ from scripts.helpers.addressable import (
     get_address,
 )
 from scripts.helpers.ticket_content import TicketContent
+from scripts.helpers.utility import make_address_bytes
+from web3 import Web3
+from eth_abi import decode  # type: ignore
 
 
 def get_ticket_balance(
@@ -95,6 +98,20 @@ class Ticket:
             entrypoint=entrypoint,
         )
         return transfer_op
+
+    def hash(self) -> int:
+        """Returns hash of the ticket. It is used in the L2 TicketTable to
+        identify the ticket."""
+
+        data = Web3.solidity_keccak(
+            ['bytes22', 'bytes'],
+            [
+                '0x' + make_address_bytes(self.ticketer),
+                '0x' + self.content.to_bytes_hex(),
+            ],
+        )
+        ticket_hash: int = decode(['uint256'], data)[0]
+        return ticket_hash
 
 
 def deserialize_ticket(owner: Addressable, raw_ticket: dict) -> Ticket:

--- a/scripts/tezos/deploy_ticketer.py
+++ b/scripts/tezos/deploy_ticketer.py
@@ -10,18 +10,18 @@ def make_extra_metadata(
     name: Optional[str],
     symbol: Optional[str],
     decimals: Optional[int],
-) -> dict[str, bytes]:
+) -> dict[str, str]:
     """Creates extra metadata for ticketer content with name, symbol and decimals"""
 
     extra_metadata = {}
     if name:
-        extra_metadata['name'] = name.encode('utf-8')
+        extra_metadata['name'] = name
 
     if symbol:
-        extra_metadata['symbol'] = symbol.encode('utf-8')
+        extra_metadata['symbol'] = symbol
 
     if decimals:
-        extra_metadata['decimals'] = str(decimals).encode('utf-8')
+        extra_metadata['decimals'] = str(decimals)
 
     return extra_metadata
 

--- a/scripts/tezos/deploy_token_bridge_helper.py
+++ b/scripts/tezos/deploy_token_bridge_helper.py
@@ -20,11 +20,17 @@ from scripts.helpers.contracts import Ticketer
     help='Private key that would be used to deploy contract on the Tezos network.',
 )
 @click.option('--rpc-url', default=None, help='Tezos RPC URL.')
+@click.option(
+    '--symbol',
+    default=None,
+    help='Optional symbol of the Token that would be added to the contract metadata if provided.',
+)
 def deploy_token_bridge_helper(
     ticketer_address: str,
     proxy_address: str,
     private_key: Optional[str],
     rpc_url: Optional[str],
+    symbol: Optional[str] = None,
 ) -> TokenBridgeHelper:
     """Deploys `token_bridge_helper` contract for provided ticketer"""
 
@@ -32,7 +38,12 @@ def deploy_token_bridge_helper(
     ticketer = Ticketer.from_address(manager, ticketer_address)
     proxy_address = proxy_address.replace('0x', '')
     proxy_bytes = bytes.fromhex(proxy_address)
-    opg = TokenBridgeHelper.originate(manager, ticketer, proxy_bytes).send()
+    opg = TokenBridgeHelper.originate(
+        client=manager,
+        ticketer=ticketer,
+        erc_proxy=proxy_bytes,
+        symbol=symbol,
+    ).send()
     manager.wait(opg)
     token_bridge_helper = TokenBridgeHelper.from_opg(manager, opg)
     return token_bridge_helper

--- a/scripts/tezos/get_ticketer_params.py
+++ b/scripts/tezos/get_ticketer_params.py
@@ -22,12 +22,16 @@ def get_ticketer_params(
     """Founds ticketer in L1 and returns it params required for L2 ERC20 token deployment"""
 
     manager = get_tezos_client(rpc_url, private_key)
+    # TODO: add ticketer validation by checking storage?
     ticketer_contract = Ticketer.from_address(manager, ticketer)
     content_bytes = ticketer_contract.get_content_bytes_hex()
     address_bytes = make_address_bytes(ticketer)
+    ticket_hash = ticketer_contract.read_ticket().hash()
     print(f'address_bytes: {address_bytes}')
     print(f'content_bytes: {content_bytes}')
+    print(f'ticket_hash: {ticket_hash}')
     return {
         'address_bytes': address_bytes,
         'content_bytes': content_bytes,
+        'ticket_hash': str(ticket_hash),
     }

--- a/tezos/tests/base.py
+++ b/tezos/tests/base.py
@@ -14,6 +14,7 @@ from scripts.helpers.contracts import (
     TicketRouterTester,
     TokenBridgeHelper,
 )
+from scripts.helpers.contracts.tokens import TokenInfo
 from typing import Optional
 from scripts.helpers.addressable import Addressable
 
@@ -61,7 +62,7 @@ class BaseTestCase(SandboxedNodeTestCase):
     def deploy_ticketer(
         self,
         token: TokenHelper,
-        extra_metadata: Optional[dict[str, bytes]] = None,
+        extra_metadata: TokenInfo = None,
     ) -> Ticketer:
         """Deploys Ticketer contract with given token and additional metadata"""
 
@@ -92,7 +93,7 @@ class BaseTestCase(SandboxedNodeTestCase):
         self,
         token_type: str = 'FA2',
         balance: int = 1000,
-        extra_metadata: Optional[dict[str, bytes]] = None,
+        extra_metadata: TokenInfo = None,
         token_id: int = 0,
     ) -> tuple[PyTezosClient, TokenHelper, Ticketer, TicketRouterTester]:
 

--- a/tezos/tests/test_communication.py
+++ b/tezos/tests/test_communication.py
@@ -1,5 +1,4 @@
 from tezos.tests.base import BaseTestCase
-from scripts.helpers.utility import pack
 
 
 class RollupCommunicationTestCase(BaseTestCase):
@@ -11,8 +10,8 @@ class RollupCommunicationTestCase(BaseTestCase):
             token_type='FA2',
             balance=1000,
             extra_metadata={
-                'decimals': pack(12, 'nat'),
-                'symbol': pack('FA2', 'string'),
+                'decimals': '12',
+                'symbol': 'FA2',
             },
         )
         erc_proxy = bytes.fromhex('fa02fa02fa02fa02fa02fa02fa02fa02fa02fa02')

--- a/tezos/tests/test_ticketer.py
+++ b/tezos/tests/test_ticketer.py
@@ -44,8 +44,8 @@ class TicketerTestCase(BaseTestCase):
         alice, token, ticketer, _ = self.default_setup(
             token_type='FA2',
             extra_metadata={
-                'decimals': '12'.encode(),
-                'symbol': 'FA2'.encode(),
+                'decimals': '12',
+                'symbol': 'FA2',
             },
         )
 
@@ -277,8 +277,8 @@ class TicketerTestCase(BaseTestCase):
         alice, token, ticketer, _ = self.default_setup(
             token_type='FA1.2',
             extra_metadata={
-                'decimals': '16'.encode(),
-                'symbol': 'tBTC'.encode(),
+                'decimals': '16',
+                'symbol': 'tBTC',
             },
         )
 
@@ -301,13 +301,7 @@ class TicketerTestCase(BaseTestCase):
             token_type='FA2',
             token_id=42,
             extra_metadata={
-                'some_strange_metadata': pack(
-                    {
-                        'list_of_strings': pack(['one', 'two'], 'list string'),
-                    },
-                    'map string bytes',
-                ),
-                'symbol': 'NFT'.encode(),
+                'symbol': 'NFT',
             },
         )
 
@@ -316,12 +310,6 @@ class TicketerTestCase(BaseTestCase):
                 'contract_address': token.address.encode(),
                 'token_type': 'FA2'.encode(),
                 'token_id': '42'.encode(),
-                'some_strange_metadata': pack(
-                    {
-                        'list_of_strings': pack(['one', 'two'], 'list string'),
-                    },
-                    'map string bytes',
-                ),
                 'symbol': 'NFT'.encode(),
             },
             'map %token_info string bytes',

--- a/tezos/tests/test_utils.py
+++ b/tezos/tests/test_utils.py
@@ -2,7 +2,6 @@ import unittest
 from scripts.helpers.contracts.tokens import CtezToken, FxhashToken
 from scripts.helpers.ticket_content import TicketContent
 from unittest.mock import Mock
-from scripts.helpers.utility import pack
 
 
 class TestTicketContentGeneration(unittest.TestCase):
@@ -68,19 +67,18 @@ class TestTicketContentGeneration(unittest.TestCase):
         token = FxhashToken(mock_contract, mock_client, token_address, 42)
         token_info_bytes = token.make_token_info_bytes(
             {
-                'decimals': pack(3, 'nat'),
-                'symbol': pack('TEST', 'string'),
-                'name': pack('Test Token', 'string'),
+                'decimals': '3',
+                'symbol': 'TEST',
+                'name': 'Test Token',
             }
         )
 
         expected_token_info_hex = (
-            '0502000000c207040100000010636f6e74726163745f616464726573730a0000'
+            '0502000000b407040100000010636f6e74726163745f616464726573730a0000'
             + '00244b54313935456238543532347635564a39395a7a483277706e5066513277'
-            + '4a664d69366807040100000008646563696d616c730a00000003050003070401'
-            + '000000046e616d650a0000001005010000000a5465737420546f6b656e070401'
-            + '0000000673796d626f6c0a0000000a0501000000045445535407040100000008'
-            + '746f6b656e5f69640a0000000234320704010000000a746f6b656e5f74797065'
-            + '0a00000003464132'
+            + '4a664d69366807040100000008646563696d616c730a00000001330704010000'
+            + '00046e616d650a0000000a5465737420546f6b656e0704010000000673796d62'
+            + '6f6c0a000000045445535407040100000008746f6b656e5f69640a0000000234'
+            + '320704010000000a746f6b656e5f747970650a00000003464132'
         )
         assert token_info_bytes.hex() == expected_token_info_hex


### PR DESCRIPTION
- [x] downgraded testcontainers to 3.7.1 (sandbox tests fix)
- [x] refactored TokenInfo, storing values as strings to fix test deployments
- [x] `bridge_token` CLI bug with ERC20 token decimals fix
- [x] Added `FaWithdrawalPrecompileHelper` which executed from `withdraw` CLI command
- [x] README.md update (simplified installation and focus on `bridge_token` CLI command