### PR TITLE
The poetry install command seems to need Make

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.10-slim
 
 RUN apt-get update && \
-    apt-get install -y curl git gcc libsodium-dev libsecp256k1-dev libgmp-dev && \
+    apt-get install -y curl git gcc libsodium-dev libsecp256k1-dev libgmp-dev make && \
     apt-get clean
 RUN curl -sSL https://install.python-poetry.org | python3 -
 ENV PATH="/root/.local/bin:${PATH}"


### PR DESCRIPTION
Without make I get this error when building the Docker image:


```
15.53     CFLAGS_FOR_BUILD        = -g -O2
15.53     LDFLAGS_FOR_BUILD       =
15.53   error: [Errno 2] No such file or directory: 'make'
15.53
15.53
15.53   at ~/.local/share/pypoetry/venv/lib/python3.10/site-packages/poetry/installation/chef.py:164 in _prepare
15.53       160│
15.53       161│                 error = ChefBuildError("\n\n".join(message_parts))
15.53       162│
15.53       163│             if error is not None:
15.53     → 164│                 raise error from None
15.53       165│
15.53       166│             return path
15.53       167│
15.53       168│     def _prepare_sdist(self, archive: Path, destination: Path | None = None) -> Path:
15.53
15.53 Note: This error originates from the build backend, and is likely not a problem with poetry but with secp256k1 (0.14.0) not supporting PEP 517 builds. You can verify this by running 'pip wheel --no-cache-dir --use-pep517 "secp256k1 (==0.14.0)"'.
15.53
------
Dockerfile:12
--------------------
  10 |     RUN git clone --branch $BRANCH https://github.com/baking-bad/etherlink-bridge.git /bridge
  11 |     WORKDIR /bridge
  12 | >>> RUN poetry install --no-root
  13 |     ENTRYPOINT ["poetry", "run"]
  14 |     CMD ["bash"]
--------------------
ERROR: failed to solve: process "/bin/sh -c poetry install --no-root" did not complete successfully: exit code: 1
```